### PR TITLE
fix: correct self-dimer flag bug and add --disable-min-max-tm flag; b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The following arguments control various aspects of the primer design process:
 - `--check-self-dimer`: Enable self-dimer checking for individual primers.
 - `--check-hairpin`: Enable hairpin structure checking for individual primers.
 - `--disable-tm-stddev`: Turns off tm-stddev config. Use if you do not want strictly similar tm values across all primers.
+- `--disable-min-max-tm`: Turns off the absolute min-tm/max-tm range filter. Use if you want primers outside the default 30–60°C window.
 - `--do-align`: Perform MAFFT multiple sequence alignment if true. Set to false if sequence already aligned.
 
 ### Example

--- a/od-msspe/Cargo.lock
+++ b/od-msspe/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "od-msspe"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "csv",

--- a/od-msspe/Cargo.toml
+++ b/od-msspe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "od-msspe"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/od-msspe/src/config.rs
+++ b/od-msspe/src/config.rs
@@ -121,6 +121,18 @@ pub struct Args {
     #[arg(
         group = "flag",
         long,
+        env = "DISABLE_MIN_MAX_TM",
+        default_value = "false",
+        value_parser = ["true", "false"],
+        help = "\
+            Turns off the absolute min-tm/max-tm range filter. Use if you want primers \
+            outside the default 30-60°C window."
+    )]
+    pub disable_min_max_tm: String,
+
+    #[arg(
+        group = "flag",
+        long,
         env = "DO_ALIGN",
         default_value = "true",
         value_parser = ["true", "false"],
@@ -160,6 +172,7 @@ pub struct ProgramConfig {
     pub check_hairpin: bool,
     pub tm_stddev: f32,
     pub disable_tm_stddev: bool,
+    pub disable_min_max_tm: bool,
     pub do_align: bool,
 
     pub(crate) primer_config: PrimerConfig,

--- a/od-msspe/src/delta_g.rs
+++ b/od-msspe/src/delta_g.rs
@@ -172,6 +172,7 @@ mod tests {
             check_hairpin: false,
             tm_stddev: 2.0,
             disable_tm_stddev: false,
+            disable_min_max_tm: false,
             do_align: false,
             primer_config: PrimerConfig {
                 kmer_size: 13,

--- a/od-msspe/src/main.rs
+++ b/od-msspe/src/main.rs
@@ -448,14 +448,14 @@ fn filter_kmers(stats: Vec<KmerStat>, program_config: ProgramConfig) -> Vec<Kmer
     stats
         .iter()
         .filter(|kmer_stat| {
-            let pass_self_any = !program_config.check_hairpin
+            let pass_self_any = !program_config.check_self_dimers
                 || (kmer_stat.self_any_th < primer_config.max_self_dimer_any_tm);
-            let pass_self_end = !program_config.check_hairpin
+            let pass_self_end = !program_config.check_self_dimers
                 || (kmer_stat.self_end_th < primer_config.max_self_dimer_end_tm);
             let pass_hairpin = !program_config.check_hairpin
                 || (kmer_stat.hairpin_th < primer_config.max_hairpin_tm);
-            let pass_min_max_tm =
-                kmer_stat.tm > primer_config.min_tm && kmer_stat.tm < primer_config.max_tm;
+            let pass_min_max_tm = program_config.disable_min_max_tm
+                || (kmer_stat.tm > primer_config.min_tm && kmer_stat.tm < primer_config.max_tm);
             let pass_tm_stddev = program_config.disable_tm_stddev || kmer_stat.tm_ok;
 
             pass_self_any
@@ -517,6 +517,7 @@ fn main() -> io::Result<()> {
         check_hairpin: args.check_hairpin.as_str() == "true",
         tm_stddev: args.tm_stddev,
         disable_tm_stddev: args.disable_tm_stddev.as_str() == "true",
+        disable_min_max_tm: args.disable_min_max_tm.as_str() == "true",
         do_align: args.do_align.as_str() == "true",
 
         primer_config: primer_config.clone(),


### PR DESCRIPTION
…ump to v1.1.0

- Fixed pass_self_any/pass_self_end to gate on check_self_dimers (not check_hairpin)
- Added --disable-min-max-tm flag so the 30-60°C absolute Tm range filter can be independently disabled; previously the only way to bypass it was --strict-tm-range, which also disabled the stddev filter (regression introduced in ab576d1)
- Bumped version to 1.1.0