### PR TITLE
fix: remove mutually exclusive group from CLI flag args

### DIFF
--- a/od-msspe/src/config.rs
+++ b/od-msspe/src/config.rs
@@ -63,7 +63,6 @@ pub struct Args {
 
     // logic based config
     #[arg(
-        group = "flag",
         long,
         env = "KEEP_ALL",
         default_value = "false",
@@ -73,7 +72,6 @@ pub struct Args {
     pub keep_all: String,
 
     #[arg(
-        group = "flag",
         long,
         env = "CHECK_CROSS_DIMERS",
         default_value = "true",
@@ -85,7 +83,6 @@ pub struct Args {
     pub check_cross_dimers: String,
 
     #[arg(
-        group = "flag",
         long,
         env = "CHECK_SELF_DIMERS",
         default_value = "true",
@@ -95,7 +92,6 @@ pub struct Args {
     pub check_self_dimers: String,
 
     #[arg(
-        group = "flag",
         long,
         env = "CHECK_HAIRPIN",
         default_value = "true",
@@ -105,7 +101,6 @@ pub struct Args {
     pub check_hairpin: String,
 
     #[arg(
-        group = "flag",
         long,
         env = "TM_STDDEV",
         default_value_t = 2.0,
@@ -114,7 +109,6 @@ pub struct Args {
     pub tm_stddev: f32,
 
     #[arg(
-        group = "flag",
         long,
         env = "DISABLE_TM_STDDEV",
         default_value = "false",
@@ -126,7 +120,6 @@ pub struct Args {
     pub disable_tm_stddev: String,
 
     #[arg(
-        group = "flag",
         long,
         env = "DISABLE_MIN_MAX_TM",
         default_value = "false",
@@ -138,7 +131,6 @@ pub struct Args {
     pub disable_min_max_tm: String,
 
     #[arg(
-        group = "flag",
         long,
         env = "DO_ALIGN",
         default_value = "true",


### PR DESCRIPTION
## Summary

All eight logic-flag arguments in `od-msspe/src/config.rs` were annotated with `group = \"flag\"`. In clap, assigning multiple arguments to the same group makes them **mutually exclusive by default** — only one argument from the group may be provided per invocation. Any attempt to pass two or more together produced a conflict error like:

```
error: the argument '--check-cross-dimers <CHECK_CROSS_DIMERS>' cannot be used with:
  --check-self-dimers <CHECK_SELF_DIMERS>
  --check-hairpin <CHECK_HAIRPIN>
```

This affected all combinations of these flags:

| Flag | Expected behaviour |
|---|---|
| `--keep-all` | Independent boolean |
| `--check-cross-dimers` | Independent boolean |
| `--check-self-dimers` | Independent boolean |
| `--check-hairpin` | Independent boolean |
| `--tm-stddev` | Independent numeric value |
| `--disable-tm-stddev` | Independent boolean |
| `--disable-min-max-tm` | Independent boolean |
| `--do-align` | Independent boolean |

None of these flags are logically exclusive — users routinely need to combine them (e.g. `--check-cross-dimers true --check-self-dimers true --check-hairpin true`, or `--disable-tm-stddev true --disable-min-max-tm true`).

## Fix

Removed `group = \"flag\"` from all eight `#[arg(...)]` annotations. No other changes. There was no corresponding `ArgGroup` struct definition anywhere in the codebase, so the group served no purpose other than accidentally enforcing mutual exclusion.

## Test plan

- [x] `cargo check` passes (verified locally)
- [x] Run with multiple flags combined, e.g. `--check-cross-dimers true --check-self-dimers true --check-hairpin true` — should no longer error
- [x] Run with `--disable-tm-stddev true --disable-min-max-tm true` — should no longer error
- [x] Run with no flags changed — default behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)